### PR TITLE
Added a null check to EmojiUtils.java

### DIFF
--- a/emojify/src/main/java/io/wax911/emojify/EmojiUtils.java
+++ b/emojify/src/main/java/io/wax911/emojify/EmojiUtils.java
@@ -218,8 +218,11 @@ public class EmojiUtils extends AbstractEmoji {
 		// surrogate pairs
 		// so at this point, we iterate through all the emojis and replace with
 		// short codes
-		for (Emoji emoji : EmojiManager.emojiData)
-			emojifiedText = emojifiedText.replace(emoji.getEmoji(), ":" + emoji.getAliases().get(0) + ":");
+		for (Emoji emoji : EmojiManager.emojiData) {
+			if(emoji != null && emojifiedText != null && emoji.getEmoji() != null && emoji.getAliases() != null){
+				emojifiedText = emojifiedText.replace(emoji.getEmoji(), ":" + emoji.getAliases().get(0) + ":");
+			}
+		}
 		return emojifiedText;
 	}
 	


### PR DESCRIPTION
I'm seeing a quite a few crashes due to this for loop in Google Play Dev console and wanted to submit a quick "fix" to you to avoid crashing on just de-emojifying. 

I thought about splitting the statement up into multiple lines to make Google Play's crash reporting more useful (to find out what's null-ing), would that be okay? 