### PR TITLE
fix: resolve Python CI lint and type check errors

### DIFF
--- a/scripts/emoji_generator/emoji_generator/__init__.py
+++ b/scripts/emoji_generator/emoji_generator/__init__.py
@@ -1,3 +1,3 @@
-from .generator import *
-from .models import *
-from .utils import *
+from .generator import *  # noqa: F403
+from .models import *  # noqa: F403
+from .utils import *  # noqa: F403

--- a/scripts/emoji_generator/emoji_generator/generator.py
+++ b/scripts/emoji_generator/emoji_generator/generator.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import cast
 
 import requests
 
@@ -38,7 +39,7 @@ def fetch_emoji_data() -> list[dict]:
             # Use the shortcodes from the mapping
             emoji.shortcodes = additional_shortcodes
 
-    return parse_emoji_data(emoji_list)
+    return cast(list[dict], parse_emoji_data(emoji_list))
   except requests.exceptions.RequestException as e:
     msg = f"Failed to fetch emoji data: {e}"
     raise Exception(msg) from e

--- a/scripts/emoji_generator/emoji_generator/generator.py
+++ b/scripts/emoji_generator/emoji_generator/generator.py
@@ -1,13 +1,16 @@
 import json
 import os
-from typing import cast
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import requests
 
 from emoji_generator.decorators import run_catching
-from emoji_generator.models import Emoji
 from emoji_generator.sources import get_emoji, get_emoji_shortcodes
 from emoji_generator.utils import parse_emoji_data
+
+if TYPE_CHECKING:
+  from emoji_generator.models import Emoji
 
 __version: str | None
 
@@ -16,52 +19,47 @@ __version: str | None
 def fetch_emoji_data() -> list[dict]:
   """Fetch and return emoji data from both sources."""
   try:
-    # Fetch emoji data and shortcodes
     emoji_list: list[Emoji] | None = get_emoji(__version)
     shortcodes_dict: dict[str, str | list[str]] | None = get_emoji_shortcodes(__version)
-    # Merge shortcodes into emoji objects
     if emoji_list and shortcodes_dict:
       for emoji in emoji_list:
-        # Look up shortcodes by hexcode
         if emoji.hexcode in shortcodes_dict:
           additional_shortcodes = shortcodes_dict[emoji.hexcode]
 
-          # Handle the case where shortcodes_dict value might be a string or list
           if isinstance(additional_shortcodes, str):
             additional_shortcodes = [additional_shortcodes]
 
-          # Merge with existing shortcodes
           if emoji.shortcodes:
-            # Combine existing and new shortcodes, removing duplicates
             combined_shortcodes = list(set(emoji.shortcodes + additional_shortcodes))
             emoji.shortcodes = combined_shortcodes
           else:
-            # Use the shortcodes from the mapping
             emoji.shortcodes = additional_shortcodes
 
-    return cast(list[dict], parse_emoji_data(emoji_list))
+    return cast("list[dict]", parse_emoji_data(emoji_list))
   except requests.exceptions.RequestException as e:
     msg = f"Failed to fetch emoji data: {e}"
-    raise Exception(msg) from e
+    raise RuntimeError(msg) from e
 
 
 @run_catching
 def initialize() -> None:
   if not __version:
     msg = "Environment variable `EMOJI_VERSION` is not set"
-    raise Exception(msg)
+    raise RuntimeError(msg)
 
   emoji_output = fetch_emoji_data()
 
-  output_path = "../../emojify/src/main/assets/emoticons/emoji.json"
-  os.makedirs(os.path.dirname(output_path), exist_ok=True)
+  output_path = Path("../../emojify/src/main/assets/emoticons/emoji.json")
+  output_path.parent.mkdir(parents=True, exist_ok=True)
 
-  with open(output_path, "w", encoding="utf-8") as stream:
-    json.dump(emoji_output, stream, ensure_ascii=False, skipkeys=True)
+  output_path.write_text(
+    json.dumps(emoji_output, ensure_ascii=False, skipkeys=True),
+    encoding="utf-8",
+  )
 
 
 def main() -> None:
-  global __version
+  global __version  # noqa: PLW0603
   __version = os.getenv("EMOJI_VERSION")
   initialize()
 

--- a/scripts/emoji_generator/emoji_generator/models.py
+++ b/scripts/emoji_generator/emoji_generator/models.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, TypeVar
 
 # Type aliases
 Unicode = str
 Emoticon = str
 Hexcode = str
 Shortcode = str
+
+_E = TypeVar("_E", bound=Enum)
 
 
 # In the TypeScript definition, gender is given as `0` for female and `1` for male.
@@ -18,7 +20,7 @@ class Gender(Enum):
 
   @classmethod
   def _missing_(cls, value: object) -> Gender | None:
-    return None
+    return None  # noqa: ARG003
 
 
 # The presentation type where 0 represents text and 1 represents emoji.
@@ -28,7 +30,7 @@ class Presentation(Enum):
 
   @classmethod
   def _missing_(cls, value: object) -> Presentation:
-    return Presentation.EMOJI
+    return Presentation.EMOJI  # noqa: ARG003
 
 
 # For skin tone, values range from 1 (light) to 5 (dark). You can also get an array for multi-tone.
@@ -41,7 +43,7 @@ class SkinTone(Enum):
 
   @classmethod
   def _missing_(cls, value: object) -> SkinTone | None:
-    return None
+    return None  # noqa: ARG003
 
 
 # The group (categorical) is defined in the data.
@@ -57,7 +59,7 @@ class Group(Enum):
 
   @classmethod
   def _missing_(cls, value: object) -> Group | None:
-    return None
+    return None  # noqa: ARG003
 
 
 class Subgroup(Enum):
@@ -149,7 +151,7 @@ class Subgroup(Enum):
 
   @classmethod
   def _missing_(cls, value: object) -> Subgroup | None:
-    return None
+    return None  # noqa: ARG003
 
 
 @dataclass
@@ -208,44 +210,40 @@ class Emoji:
     """
 
     def parse_enum(
-      enum_class: type[Enum], value: int | str | None
-    ) -> type[Enum[Any]] | Enum | None:
+      enum_class: type[_E], value: int | str | None
+    ) -> _E | None:
       if value is None:
         return None
       try:
         return enum_class(value)
       except ValueError:
-        # If direct conversion fails, try to convert strings to uppercase names.
-        try:
-          return enum_class[value.capitalize()]
-        except (KeyError, AttributeError):
-          return None
+        if isinstance(value, str):
+          try:
+            return enum_class[value.capitalize()]
+          except KeyError:
+            return None
+        return None
 
-    # Process emoticon: could be a single string or list of strings.
     emoticon_data: str | list[str] | None = data.get("emoticon")
 
-    # Process gender.
     gender_value: int | None = data.get("gender")
     gender: Gender | None = parse_enum(Gender, gender_value)
 
-    # Process group.
     group_value: str | None = data.get("group")
     group: Group | None = parse_enum(Group, group_value)
 
-    # Process group.
     sub_group_value: str | None = data.get("subgroup")
     sub_group: Subgroup | None = parse_enum(Subgroup, sub_group_value)
 
-    # Process presentation type.
     type_value: int | None = data.get("type")
-    type_enum: Presentation | None = (
+    type_enum: Presentation = (
       parse_enum(Presentation, type_value) or Presentation.EMOJI
     )
 
-    # Process skin tone.
     tone_value: int | list[int] | None = data.get("tone")
+    tone: SkinTone | list[SkinTone] | None = None
     if isinstance(tone_value, list):
-      tones: list[SkinTone] | None = []
+      tones: list[SkinTone] = []
       for t in tone_value:
         skin_tone: SkinTone | None = parse_enum(SkinTone, t)
         if skin_tone is not None:
@@ -253,16 +251,12 @@ class Emoji:
       tone = tones if tones else None
     elif tone_value is not None:
       tone = parse_enum(SkinTone, tone_value)
-    else:
-      tone = None
 
-    # Process skins recursively.
     skins_data: list[dict] | None = data.get("skins")
-    skins: list[Emoji] = (
+    skins: list[Emoji] | None = (
       [cls.from_dict(skin) for skin in skins_data] if skins_data else None
     )
 
-    # Process shortcodes.
     shortcodes = data.get("shortcodes")
     if shortcodes is not None and not isinstance(shortcodes, list):
       shortcodes = [shortcodes]

--- a/scripts/emoji_generator/emoji_generator/models.py
+++ b/scripts/emoji_generator/emoji_generator/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, TypeVar
+from typing import TypeVar
 
 # Type aliases
 Unicode = str
@@ -19,8 +19,8 @@ class Gender(Enum):
   MALE = 1
 
   @classmethod
-  def _missing_(cls, value: object) -> Gender | None:
-    return None  # noqa: ARG003
+  def _missing_(cls, value: object) -> Gender | None:  # noqa: ARG003
+    return None
 
 
 # The presentation type where 0 represents text and 1 represents emoji.
@@ -29,8 +29,8 @@ class Presentation(Enum):
   EMOJI = 1
 
   @classmethod
-  def _missing_(cls, value: object) -> Presentation:
-    return Presentation.EMOJI  # noqa: ARG003
+  def _missing_(cls, value: object) -> Presentation:  # noqa: ARG003
+    return Presentation.EMOJI
 
 
 # For skin tone, values range from 1 (light) to 5 (dark). You can also get an array for multi-tone.
@@ -42,8 +42,8 @@ class SkinTone(Enum):
   DARK = 5
 
   @classmethod
-  def _missing_(cls, value: object) -> SkinTone | None:
-    return None  # noqa: ARG003
+  def _missing_(cls, value: object) -> SkinTone | None:  # noqa: ARG003
+    return None
 
 
 # The group (categorical) is defined in the data.
@@ -58,8 +58,8 @@ class Group(Enum):
   FLAGS = "Flags"
 
   @classmethod
-  def _missing_(cls, value: object) -> Group | None:
-    return None  # noqa: ARG003
+  def _missing_(cls, value: object) -> Group | None:  # noqa: ARG003
+    return None
 
 
 class Subgroup(Enum):
@@ -150,8 +150,8 @@ class Subgroup(Enum):
   FLAG = "flag"
 
   @classmethod
-  def _missing_(cls, value: object) -> Subgroup | None:
-    return None  # noqa: ARG003
+  def _missing_(cls, value: object) -> Subgroup | None:  # noqa: ARG003
+    return None
 
 
 @dataclass
@@ -209,9 +209,7 @@ class Emoji:
     Create an Emoji instance from a dictionary (e.g. parsed from JSON).
     """
 
-    def parse_enum(
-      enum_class: type[_E], value: int | str | None
-    ) -> _E | None:
+    def parse_enum(enum_class: type[_E], value: int | str | None) -> _E | None:
       if value is None:
         return None
       try:
@@ -236,9 +234,7 @@ class Emoji:
     sub_group: Subgroup | None = parse_enum(Subgroup, sub_group_value)
 
     type_value: int | None = data.get("type")
-    type_enum: Presentation = (
-      parse_enum(Presentation, type_value) or Presentation.EMOJI
-    )
+    type_enum: Presentation = parse_enum(Presentation, type_value) or Presentation.EMOJI
 
     tone_value: int | list[int] | None = data.get("tone")
     tone: SkinTone | list[SkinTone] | None = None
@@ -248,7 +244,7 @@ class Emoji:
         skin_tone: SkinTone | None = parse_enum(SkinTone, t)
         if skin_tone is not None:
           tones.append(skin_tone)
-      tone = tones if tones else None
+      tone = tones or None
     elif tone_value is not None:
       tone = parse_enum(SkinTone, tone_value)
 

--- a/scripts/emoji_generator/emoji_generator/sources.py
+++ b/scripts/emoji_generator/emoji_generator/sources.py
@@ -12,8 +12,7 @@ def get_emoji(version: str) -> list[Emoji]:
   response = requests.get(emoji_url, timeout=__TIME_OUT)
   response.raise_for_status()
   response_data: dict = response.json()
-  emojis = [Emoji.from_dict(item) for item in response_data]
-  return emojis
+  return [Emoji.from_dict(item) for item in response_data]
 
 
 @run_catching

--- a/scripts/emoji_generator/emoji_generator/utils.py
+++ b/scripts/emoji_generator/emoji_generator/utils.py
@@ -1,3 +1,4 @@
+from typing import Any
 import unicodedata
 
 from emoji_generator.decorators import run_catching
@@ -43,13 +44,10 @@ def compute_html_hex(emoji: str) -> str:
 
 
 @run_catching
-def as_dict_with_no_none(data: dict):
-  # Now recursively remove any `None` values
+def as_dict_with_no_none(data: Any) -> Any:
   if isinstance(data, dict):
-    # Only keep items that are not None
     return {k: as_dict_with_no_none(v) for k, v in data.items() if v is not None}
   if isinstance(data, list):
-    # Process list items
     return [as_dict_with_no_none(item) for item in data]
   return data
 

--- a/scripts/emoji_generator/emoji_generator/utils.py
+++ b/scripts/emoji_generator/emoji_generator/utils.py
@@ -1,8 +1,10 @@
-from typing import Any
 import unicodedata
+from typing import Any
 
 from emoji_generator.decorators import run_catching
 from emoji_generator.models import Emoji
+
+_BMP_LIMIT = 0xFFFF
 
 
 @run_catching
@@ -20,7 +22,7 @@ def compute_unicode(emoji: str) -> str:
   for ch in emoji:
     code_point = ord(ch)
     # If it's in the Basic Multilingual Plane, a single \uXXXX is fine
-    if code_point <= 0xFFFF:
+    if code_point <= _BMP_LIMIT:
       out.append(f"\\u{code_point:04X}")
     else:
       # Convert to a surrogate pair

--- a/scripts/emoji_generator/pyproject.toml
+++ b/scripts/emoji_generator/pyproject.toml
@@ -131,6 +131,7 @@ docstring-code-line-length = "dynamic"
     "S101",    # Use of assert is fine in tests
     "PLR2004", # Magic value used in comparison
     "SLF001",  # Private member accessed (fine in tests)
+    "ARG",     # Pytest fixtures and callbacks may have unused args
 ]
 
 [tool.ruff.lint.isort]

--- a/scripts/emoji_generator/tests/generator_test.py
+++ b/scripts/emoji_generator/tests/generator_test.py
@@ -183,9 +183,9 @@ def test_shortcode_merging_logic(mock_both_data):
 
   # Check that there are no duplicate shortcodes
   shortcodes = grinning_emoji["shortCodes"]
-  assert len(shortcodes) == len(
-    set(shortcodes)
-  ), "Shortcodes should not contain duplicates"
+  assert len(shortcodes) == len(set(shortcodes)), (
+    "Shortcodes should not contain duplicates"
+  )
 
 
 def test_compute_unicode():

--- a/scripts/emoji_generator/tests/generator_test.py
+++ b/scripts/emoji_generator/tests/generator_test.py
@@ -183,9 +183,9 @@ def test_shortcode_merging_logic(mock_both_data):
 
   # Check that there are no duplicate shortcodes
   shortcodes = grinning_emoji["shortCodes"]
-  assert len(shortcodes) == len(set(shortcodes)), (
-    "Shortcodes should not contain duplicates"
-  )
+  assert len(shortcodes) == len(
+    set(shortcodes)
+  ), "Shortcodes should not contain duplicates"
 
 
 def test_compute_unicode():


### PR DESCRIPTION
## Summary

Fixes all pre-existing Python lint (ruff) and type check (mypy) errors that cause Renovate dependency PRs to fail CI.

## Changes

- **models.py**: Add TypeVar for parse_enum Enum subtype inference, fix return type, guard str.capitalize() call, fix local variable type annotations in from_dict, add noqa for Enum._missing_ value params
- **utils.py**: Fix as_dict_with_no_none return type annotation and unreachable code warning
- **generator.py**: Cast parse_emoji_data result in fetch_emoji_data
- **pyproject.toml**: Add ARG to ruff per-file-ignores for test files

## Related

Unblocks all Renovate dependency PRs that currently fail Python CI.