### PR TITLE
perf(serializer): generate the Moshi adapter with KSP instead of reflection

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     /** Depend on the compose compiler plugin, applied to the sample module only */
     implementation(libs.jetbrains.compose.compiler.gradle)
 
+    /** Depend on the ksp plugin, applied to the moshi serializer for adapter code generation */
+    implementation(libs.google.ksp.gradle)
+
     /** Depend on the dokka plugin, since we want to access it in our plugin */
     implementation(libs.jetbrains.dokka.gradle)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ jackson-databind = "2.22.2"
 ktlint = "1.0.1"
 
 gradle-plugin = "9.3.2"
+google-ksp = "2.3.11"
 
 androidx-core = "1.19.0"
 androidx-emoji = "1.1.0"
@@ -32,11 +33,14 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 [libraries]
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson-databind" }
+moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi-kotlin" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi-kotlin" }
+moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi-kotlin" }
 timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
 junit = { module = "junit:junit", version = "4.13.2" }
 
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "gradle-plugin" }
+google-ksp-gradle = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "google-ksp" }
 
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 

--- a/serializer/moshi/build.gradle.kts
+++ b/serializer/moshi/build.gradle.kts
@@ -2,6 +2,7 @@ import io.wax911.emoji.buildSrc.Libraries
 
 plugins {
     id("io.wax911.emojify")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -10,5 +11,6 @@ android {
 
 dependencies {
     implementation(project(Libraries.AniTrend.Emojify.contract))
-    api(libs.moshi.kotlin)
+    api(libs.moshi)
+    ksp(libs.moshi.kotlin.codegen)
 }

--- a/serializer/moshi/src/main/kotlin/io/wax911/emojify/serializer/moshi/MoshiDeserializer.kt
+++ b/serializer/moshi/src/main/kotlin/io/wax911/emojify/serializer/moshi/MoshiDeserializer.kt
@@ -18,7 +18,6 @@ package io.wax911.emojify.serializer.moshi
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.wax911.emojify.contract.model.IEmoji
 import io.wax911.emojify.contract.serializer.IEmojiDeserializer
 import okio.buffer
@@ -29,7 +28,7 @@ import java.io.InputStream
  * Default implementation for moshi
  */
 class MoshiDeserializer : IEmojiDeserializer {
-    private val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+    private val moshi = Moshi.Builder().build()
 
     override fun decodeFromStream(inputStream: InputStream): List<IEmoji> {
         val myType = Types.newParameterizedType(List::class.java, MoshiEmoji::class.java)

--- a/serializer/moshi/src/test/kotlin/io/wax911/emojify/serializer/moshi/MoshiDeserializerTest.kt
+++ b/serializer/moshi/src/test/kotlin/io/wax911/emojify/serializer/moshi/MoshiDeserializerTest.kt
@@ -1,0 +1,62 @@
+package io.wax911.emojify.serializer.moshi
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MoshiDeserializerTest {
+
+    @Test
+    fun `check that entries are decoded through the generated adapter`() {
+        val json =
+            """
+            [
+              {
+                "emoji": "😀",
+                "description": "grinning face",
+                "supportsFitzpatrick": false,
+                "tags": ["happy", "smile"],
+                "unicode": "U+1F600",
+                "htmlDec": "&#128512;",
+                "htmlHex": "&#x1f600;",
+                "shortCodes": ["grinning"]
+              }
+            ]
+            """.trimIndent()
+
+        val result = MoshiDeserializer().decodeFromStream(json.byteInputStream())
+
+        assertEquals(1, result.size)
+        val emoji = result.first()
+        assertEquals("😀", emoji.emoji)
+        assertEquals("grinning face", emoji.description)
+        assertEquals(listOf("grinning"), emoji.shortCodes)
+        assertEquals(listOf("happy", "smile"), emoji.tags)
+        assertEquals("&#128512;", emoji.htmlDec)
+        assertEquals("&#x1f600;", emoji.htmlHex)
+    }
+
+    @Test
+    fun `check that omitted optional fields fall back to their defaults`() {
+        // The bundled asset leaves supportsFitzpatrick and tags off most entries, so the adapter
+        // has to honour the constructor defaults rather than fail or null them out.
+        val json =
+            """
+            [
+              {
+                "emoji": "🔥",
+                "description": "fire",
+                "unicode": "U+1F525",
+                "htmlDec": "&#128293;",
+                "htmlHex": "&#x1f525;"
+              }
+            ]
+            """.trimIndent()
+
+        val emoji = MoshiDeserializer().decodeFromStream(json.byteInputStream()).first()
+
+        assertEquals(false, emoji.supportsFitzpatrick)
+        assertNull(emoji.shortCodes)
+        assertNull(emoji.tags)
+    }
+}


### PR DESCRIPTION
## Description of Bug

`MoshiEmoji` is annotated `@JsonClass(generateAdapter = true)`, but `serializer/moshi/build.gradle.kts`
applies only the shared `io.wax911.emojify` convention plugin — no KSP and no `moshi-kotlin-codegen`
— and there is no KSP in `buildSrc` either, so the generated adapter is never produced. At runtime
`MoshiDeserializer` therefore falls back to `Moshi.Builder().addLast(KotlinJsonAdapterFactory())` and
parses the ~480 KB `emoticons/emoji.json` asset entirely by reflection.

By contrast `serializer/kotlinx/build.gradle.kts` does apply its `kotlinx-serialization` plugin, so
that serializer is codegen-backed. The annotation on `MoshiEmoji` suggests codegen was intended for
the Moshi path as well.

## Reproduction Steps

1. Depend on `emojify` + `contract` + `moshi`.
2. Time the factory call on a device:

```kotlin
val start = System.currentTimeMillis()
val emojiManager = EmojiManager.create(context, MoshiDeserializer())
Log.d("emoji", "create took ${System.currentTimeMillis() - start}ms")
```

3. On a physical device with a debug build this reports **~1.5 s**; on an API 35 arm64 emulator,
   **2.0-2.5 s**.
4. Inspect the built `moshi` artifact: it contains `MoshiDeserializer` and `MoshiEmoji`, but no
   generated `MoshiEmojiJsonAdapter`, confirming codegen never ran.

## Additional Context

Why it bites in practice: with Hilt the manager is typically provided as a `@Singleton`, so the first
field injection that asks for it resolves it **on the main thread** — in my case inside a fragment
transaction, which produced a visible stall when opening a screen containing comments. Resolving it
via a `Provider` on a background dispatcher at application startup fixes the symptom, but the ~1.5 s
of CPU is still paid on every cold start.

I measured the difference rather than guessing. Implementing `IEmojiDeserializer` in my own module
with an identical model — same fields, same `@Json` names, the only change being that KSP actually
runs, and a plain `Moshi.Builder().build()` so the generated adapter is used — gives, in one process,
alternating A/B/A/B to cancel out page-cache and JIT warm-up (API 35 arm64 emulator, debug build):

| | reflection (`MoshiDeserializer`) | codegen (same model, KSP applied) |
|---|---|---|
| first `create()` in the process (cold) | **2545 ms** / **2053 ms** | **26 ms** / **29 ms** |
| subsequent `create()` (warm) | 58 ms / 79 ms | 22 ms / 17 ms |

Both produced 1603 entries, and comparing all of them field by field across every `IEmoji` property
gave **0 mismatches**, so this is like-for-like output.

The interesting part is the cold/warm split: the reflective path costs ~2 s the *first* time and
under 100 ms afterwards, so almost all of it is one-time `kotlin-reflect` initialisation rather than
per-parse work. Since `EmojiManager` is normally a singleton created once per process, real apps
always pay the expensive first call.

Suggested fix: add KSP + `moshi-kotlin-codegen` to the `serializer/moshi` module — no API change, and
on these numbers it removes ~2 s of cold-start CPU.

It may also be worth a line in the README noting that `create()` performs blocking asset I/O plus a
full parse of the emoji list, and should be called off the main thread.
````